### PR TITLE
Able to have health_check page while maintenance mode

### DIFF
--- a/lib/rack/turnout.rb
+++ b/lib/rack/turnout.rb
@@ -21,6 +21,11 @@ class Rack::Turnout
       page = page_class.new(settings.reason, env: env)
 
       page.rack_response(settings.response_code, settings.retry_after)
+    elsif settings && request.is_health_check?(settings)
+      page_class = Turnout::HealthCheckPage.best_for(env)
+      page = page_class.new(settings.reason, env: env)
+
+      page.rack_response(settings.health_check_response_code, settings.retry_after)
     else
       @app.call(env)
     end

--- a/lib/turnout.rb
+++ b/lib/turnout.rb
@@ -2,6 +2,7 @@ module Turnout
   require 'turnout/configuration'
   require 'turnout/maintenance_file'
   require 'turnout/maintenance_page'
+  require 'turnout/health_check_page'
   require 'turnout/request'
   require 'turnout/engine' if defined? Rails
 

--- a/lib/turnout/configuration.rb
+++ b/lib/turnout/configuration.rb
@@ -11,6 +11,10 @@ module Turnout
       :skip_middleware,
       :default_allowed_paths,
       :default_response_code,
+      :health_check_pages_path,
+      :default_health_check_page,
+      :default_health_check_paths,
+      :default_health_check_response_code,
       :default_retry_after,
       :i18n
     ].freeze
@@ -29,6 +33,12 @@ module Turnout
       @default_allowed_paths = []
       @default_allowed_ips = []
       @default_response_code = 503
+
+      @health_check_pages_path = app_root.join('public').to_s
+      @default_health_check_page = Turnout::HealthCheckPage::HTML
+      @default_health_check_paths = []
+      @default_health_check_response_code = 200
+
       @default_retry_after = 7200 # 2 hours by default
       @i18n = Turnout::OrderedOptions.new
       @i18n.railties_load_path = []

--- a/lib/turnout/health_check_page.rb
+++ b/lib/turnout/health_check_page.rb
@@ -1,0 +1,24 @@
+require 'pathname'
+module Turnout
+  module HealthCheckPage
+    require 'rack/accept'
+
+    def self.all
+      @all ||= []
+    end
+
+    def self.best_for(env)
+      request = Rack::Accept::Request.new(env)
+
+      all_types = all.map(&:media_types).flatten
+      best_type = request.best_media_type(all_types)
+      best = all.find { |page| page.media_types.include?(best_type) && File.exist?(page.new.custom_path) }
+      best || Turnout.config.default_health_check_page
+    end
+
+    require 'turnout/health_check_page/base'
+    require 'turnout/health_check_page/erb'
+    require 'turnout/health_check_page/html'
+    require 'turnout/health_check_page/json'
+  end
+end

--- a/lib/turnout/health_check_page/base.rb
+++ b/lib/turnout/health_check_page/base.rb
@@ -1,0 +1,83 @@
+module Turnout
+  module HealthCheckPage
+    class Base
+      attr_reader :reason
+
+      def initialize(reason = nil, options = {})
+        @options = options.is_a?(Hash) ? options : {}
+        @reason = reason
+      end
+
+      def rack_response(code = nil, retry_after = nil)
+        code ||= Turnout.config.response_code_for_health_check
+        [code, headers(retry_after), body]
+      end
+
+      # Override with an array of media type strings. i.e. text/html
+      def self.media_types
+        raise NotImplementedError, '.media_types must be overridden in subclasses'
+      end
+      def media_types() self.class.media_types end
+
+      # Override with a file extension value like 'html' or 'json'
+      def self.extension
+        raise NotImplementedError, '.extension must be overridden in subclasses'
+      end
+      def extension() self.class.extension end
+
+      def custom_path
+        Pathname.new(Turnout.config.health_check_pages_path).join(filename)
+      end
+
+      protected
+
+      def self.inherited(subclass)
+        HealthCheckPage.all << subclass
+      end
+
+      def headers(retry_after = nil)
+        headers = {'Content-Type' => media_types.first, 'Content-Length' => length}
+        # Include the Retry-After header unless it wasn't specified
+        headers['Retry-After'] = retry_after.to_s unless retry_after.nil?
+        headers
+      end
+
+      def length
+        content.bytesize.to_s
+      end
+
+      def body
+        [content]
+      end
+
+      def content
+         file_content.gsub(/{{\s?reason\s?}}/, reason)
+      end
+
+      def file_content
+        begin
+          File.read(path)
+        rescue StandardError
+          ""
+        end
+      end
+
+      def path
+        if File.exist? custom_path
+          custom_path
+        else
+          default_path
+        end
+      end
+
+      def default_path
+        File.expand_path("../../../../public/#{filename}", __FILE__)
+      end
+
+
+      def filename
+        "health_check_page.#{extension}"
+      end
+    end
+  end
+end

--- a/lib/turnout/health_check_page/erb.rb
+++ b/lib/turnout/health_check_page/erb.rb
@@ -1,0 +1,22 @@
+require 'erb'
+require 'tilt'
+require 'tilt/erb'
+require_relative './html'
+require_relative '../i18n/internationalization'
+
+module Turnout
+  module HealthCheckPage
+    class Erb < Turnout::HealthCheckPage::HTML
+
+      def content
+        Turnout::Internationalization.initialize_i18n(@options[:env])
+        Tilt.new(File.expand_path(path)).render(self, {reason: reason}.merge(@options))
+      end
+      
+      def self.extension
+        'html.erb'
+      end
+
+    end
+  end
+end

--- a/lib/turnout/health_check_page/html.rb
+++ b/lib/turnout/health_check_page/html.rb
@@ -1,0 +1,21 @@
+require_relative './base'
+module Turnout
+  module HealthCheckPage
+    class HTML < Base
+      def reason
+        super.to_s.split("\n").map{|txt| "<p>#{txt}</p>" }.join("\n")
+      end
+
+      def self.media_types
+        %w{
+          text/html
+          application/xhtml+xml
+        }
+      end
+
+      def self.extension
+        'html'
+      end
+    end
+  end
+end

--- a/lib/turnout/health_check_page/json.rb
+++ b/lib/turnout/health_check_page/json.rb
@@ -1,0 +1,26 @@
+require 'json'
+
+module Turnout
+  module HealthCheckPage
+    class JSON < Base
+      def reason
+        super.to_s.to_json
+      end
+
+      def self.media_types
+        %w{
+          application/json
+          text/json
+          application/x-javascript
+          text/javascript
+          text/x-javascript
+          text/x-json
+        }
+      end
+
+      def self.extension
+        'json'
+      end
+    end
+  end
+end

--- a/lib/turnout/maintenance_file.rb
+++ b/lib/turnout/maintenance_file.rb
@@ -5,7 +5,7 @@ module Turnout
   class MaintenanceFile
     attr_reader :path
 
-    SETTINGS = [:reason, :allowed_paths, :allowed_ips, :response_code, :retry_after]
+    SETTINGS = [:reason, :allowed_paths, :allowed_ips, :response_code, :retry_after, :health_check_paths, :health_check_response_code]
     attr_reader(*SETTINGS)
 
     def initialize(path)
@@ -14,6 +14,8 @@ module Turnout
       @allowed_paths = Turnout.config.default_allowed_paths
       @allowed_ips = Turnout.config.default_allowed_ips
       @response_code = Turnout.config.default_response_code
+      @health_check_paths = Turnout.config.default_health_check_paths
+      @health_check_response_code = Turnout.config.default_health_check_response_code
       @retry_after = Turnout.config.default_retry_after
 
       import_yaml if exists?
@@ -94,6 +96,18 @@ module Turnout
     end
 
     # Splits strings on commas for easier importing of environment variables
+    def health_check_paths=(paths)
+      if paths.is_a? String
+        # Grab everything between commas that aren't escaped with a backslash
+        paths = paths.to_s.split(/(?<!\\),\ ?/).map do |path|
+          path.strip.gsub('\,', ',') # remove the escape characters
+        end
+      end
+
+      @health_check_paths = paths
+    end
+
+    # Splits strings on commas for easier importing of environment variables
     def allowed_ips=(ips)
       ips = ips.to_s.split(',') if ips.is_a? String
 
@@ -102,6 +116,10 @@ module Turnout
 
     def response_code=(code)
       @response_code = code.to_i
+    end
+
+    def health_check_response_code=(code)
+      @health_check_response_code = code.to_i
     end
 
     def dir_path

--- a/lib/turnout/request.rb
+++ b/lib/turnout/request.rb
@@ -10,6 +10,12 @@ module Turnout
       path_allowed?(settings.allowed_paths) || ip_allowed?(settings.allowed_ips)
     end
 
+    def is_health_check?(settings)
+      settings.health_check_paths.any? do |health_check_path|
+        rack_request.path == health_check_path
+      end
+    end
+
     private
 
     attr_reader :rack_request


### PR DESCRIPTION
In some case we still need the `health_check` page while in maintenance mode. 
-> Add new settings:
- `health_check_pages_path`: path to health_check_page, like `maintenance_pages_path`
- `default_health_check_page`: type of health_check_page (HTML, JSON, ERB), like `default_maintenance_page`
- `default_health_check_paths`: health_check's paths, like `default_allowed_paths`
- `default_health_check_response_code`: like `default_response_code`


We can use the setting like:
```ruby
  Turnout.configure do |config|
      config.skip_middleware = true
      config.maintenance_pages_path = config.app_root.join('public').to_s
      config.default_maintenance_page = Turnout::MaintenancePage::HTML
      config.default_response_code = 503
      config.health_check_pages_path = config.app_root.join('public').to_s
      config.default_allowed_paths = ["^/health_check"]
      config.default_health_check_paths = ["/health_check"]
      config.default_health_check_page = Turnout::HealthCheckPage::HTML
      config.default_health_check_response_code = 200
    end
```